### PR TITLE
Add information about bareos pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ docker run --name bareos_exporter -p 9625:9625 -d vierbergenlars/bareos_exporter
 ```
 ### Metrics
 
-- Total amout of bytes and files saved
+- Total amount of bytes and files saved
 - Latest executed job metrics (level, errors, execution time, bytes and files saved)
 - Latest full job (level = F) metrics
 - Amount of scheduled jobs
+- Amount of bytes and volumes in pools
 
 ### Flags
 

--- a/dataaccess/dataaccess.go
+++ b/dataaccess/dataaccess.go
@@ -23,6 +23,7 @@ type sqlQueries struct {
 	LastJobStatus string
 	LastFullJob   string
 	ScheduledJobs string
+	PoolInfo      string
 }
 
 var mysqlQueries *sqlQueries = &sqlQueries{
@@ -33,6 +34,7 @@ var mysqlQueries *sqlQueries = &sqlQueries{
 	LastJobStatus: "SELECT JobStatus FROM Job WHERE Name = ? ORDER BY StartTime DESC LIMIT 1",
 	LastFullJob:   "SELECT Level,JobBytes,JobFiles,JobErrors,StartTime FROM Job WHERE Name = ? AND Level = 'F' AND JobStatus IN('T', 'W') ORDER BY StartTime DESC LIMIT 1",
 	ScheduledJobs: "SELECT COUNT(SchedTime) AS JobsScheduled FROM Job WHERE Name = ? AND SchedTime >= ?",
+	PoolInfo:      "SELECT p.name, sum(m.volbytes) as bytes, COUNT(m) as volumes, 0 as prunable FROM Media m LEFT JOIN Pool p ON m.poolid = p.poolid GROUP BY p.name",
 }
 
 var postgresQueries *sqlQueries = &sqlQueries{
@@ -43,6 +45,7 @@ var postgresQueries *sqlQueries = &sqlQueries{
 	LastJobStatus: "SELECT JobStatus FROM job WHERE Name = $1 ORDER BY StartTime DESC LIMIT 1",
 	LastFullJob:   "SELECT Level,JobBytes,JobFiles,JobErrors,StartTime FROM job WHERE Name = $1 AND Level = 'F' AND JobStatus IN('T', 'W') ORDER BY StartTime DESC LIMIT 1",
 	ScheduledJobs: "SELECT COUNT(SchedTime) AS JobsScheduled FROM job WHERE Name = $1 AND SchedTime >= $2",
+	PoolInfo:      "SELECT p.name, sum(m.volbytes) AS bytes, count(m) AS volumes, (not exists(select * from jobmedia jm where jm.mediaid = m.mediaid)) AS prunable FROM media m LEFT JOIN pool p ON m.poolid = p.poolid GROUP BY p.name, prunable",
 }
 
 // GetConnection opens a new db connection
@@ -205,6 +208,29 @@ func (connection Connection) ScheduledJobs(server string) (*types.ScheduledJob, 
 	}
 
 	return &schedJob, err
+}
+
+func (connection Connection) PoolInfo() ([]types.PoolInfo, error) {
+	results, err := connection.execQuery(connection.queries.PoolInfo)
+	defer results.Close()
+
+	if err != nil {
+		return nil, err
+	}
+
+	var poolInfoList []types.PoolInfo
+
+	for results.Next() {
+		var poolInfo types.PoolInfo
+		err = results.Scan(&poolInfo.Name, &poolInfo.Bytes, &poolInfo.Volumes, &poolInfo.Prunable)
+		if err != nil {
+			return nil, err
+		}
+		poolInfoList = append(poolInfoList, poolInfo)
+	}
+
+	return poolInfoList, nil
+
 }
 
 // Close the database connection

--- a/types/poolinfo.go
+++ b/types/poolinfo.go
@@ -1,0 +1,9 @@
+package types
+
+// PoolInfo models query result of pool information
+type PoolInfo struct {
+	Name     string `json:"name"`
+	Volumes  int    `json:"volumes"`
+	Bytes    int    `json:"files"`
+	Prunable bool   `json:"prunable"`
+}


### PR DESCRIPTION
Add metrics for storage capacity used by pools and for number of volumes inside a pool.

Pools are separated into non-prunable volumes (volumes which still have jobs pointing to them) and prunable volumes (volumes which have no jobs referencing them anymore)