### PR TITLE
Switch GitHub action to properly build amd64 binaries

### DIFF
--- a/.github/workflows/release-go.yaml
+++ b/.github/workflows/release-go.yaml
@@ -1,72 +1,26 @@
+---
 name: Build release binaries
 on:
-    release:
-        types:
-            - published
+  release:
+    types:
+      - published
 jobs:
-  release-linux-386:
-    name: release linux/386
+  releases-matrix:
+    name: Release Go Binary
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, windows/386, windows/amd64, darwin/amd64
+        goos: [linux, windows, darwin]
+        goarch: ["386", amd64]
+        exclude:
+          - goarch: "386"
+            goos: darwin
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: compile and release
-      uses: ngs/go-release.action@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GOARCH: "386"
-        GOOS: linux
-  release-linux-amd64:
-    name: release linux/amd64
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: compile and release
-      uses: ngs/go-release.action@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GOARCH: amd64
-        GOOS: linux
-  release-darwin-386:
-    name: release darwin/386
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: compile and release
-      uses: ngs/go-release.action@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GOARCH: "386"
-        GOOS: darwin
-  release-darwin-amd64:
-    name: release darwin/amd64
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: compile and release
-      uses: ngs/go-release.action@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GOARCH: amd64
-        GOOS: darwin
-  release-windows-386:
-    name: release windows/386
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: compile and release
-      uses: ngs/go-release.action@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GOARCH: "386"
-        GOOS: windows
-  release-windows-amd64:
-    name: release windows/amd64
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: compile and release
-      uses: ngs/go-release.action@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GOARCH: amd64
-        GOOS: windows
+      uses: wangyoucao577/go-release-action@v1.17
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}


### PR DESCRIPTION
Currently amd64 pre-built binaries are not working properly as they are not staticly built, please see this issue: https://github.com/ngs/go-release.action/issues/6

```
$ tar xvzf bareos_exporter_v0.5.5_linux_amd64.tar.gz 
bareos_exporter
$ ./bareos_exporter 
bash: ./bareos_exporter: No such file or directory
$ ldd bareos_exporter
	linux-vdso.so.1 =>  (0x00007fffd0fe6000)
	libc.musl-x86_64.so.1 => not found
```
```
Error: 
 Problem: conflicting requests
  - nothing provides libc.musl-x86_64.so.1()(64bit) needed by bareos_exporter-0.5.5-1.el8.x86_64
```

I've switch action to fix this issue. `wangyoucao577/go-release.action` also appears to be better maintained than an existing one.